### PR TITLE
Enhancement: Edit prefixes for Add / Edit command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -34,6 +34,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
+        // problem is here: works with a/ but not a:
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,7 +9,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n: ");
     public static final Prefix PREFIX_PHONE = new Prefix("p: ");
     public static final Prefix PREFIX_EMAIL = new Prefix("e: ");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a: ");
-    public static final Prefix PREFIX_TAG = new Prefix("t: ");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,6 +10,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p: ");
     public static final Prefix PREFIX_EMAIL = new Prefix("e: ");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_TAG = new Prefix("t: ");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,9 +6,9 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n: ");
-    public static final Prefix PREFIX_PHONE = new Prefix("p: ");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e: ");
+    public static final Prefix PREFIX_NAME = new Prefix("n:");
+    public static final Prefix PREFIX_PHONE = new Prefix("p:");
+    public static final Prefix PREFIX_EMAIL = new Prefix("e:");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a:");
     public static final Prefix PREFIX_TAG = new Prefix("t:");
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,7 +9,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n: ");
     public static final Prefix PREFIX_PHONE = new Prefix("p: ");
     public static final Prefix PREFIX_EMAIL = new Prefix("e: ");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("a:");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,7 +9,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n: ");
     public static final Prefix PREFIX_PHONE = new Prefix("p: ");
     public static final Prefix PREFIX_EMAIL = new Prefix("e: ");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("a: ");
     public static final Prefix PREFIX_TAG = new Prefix("t: ");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,9 +6,9 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
+    public static final Prefix PREFIX_NAME = new Prefix("n: ");
+    public static final Prefix PREFIX_PHONE = new Prefix("p: ");
+    public static final Prefix PREFIX_EMAIL = new Prefix("e: ");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,6 +10,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p: ");
     public static final Prefix PREFIX_EMAIL = new Prefix("e: ");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a:");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_TAG = new Prefix("t:");
 
 }

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -177,7 +177,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_EMAIL_DESC + ADDRESS_DESC_AMY;
         assertCommandFailure(command, Email.MESSAGE_EMAIL_CONSTRAINTS);
 
-        // Test fails when prefix is edited to "a:" from "a/".
+        // Test fails when prefix is edited to "a: " from "a:".
         /* Case: invalid address -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + INVALID_ADDRESS_DESC;
         assertCommandFailure(command, Address.MESSAGE_ADDRESS_CONSTRAINTS);

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -177,6 +177,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_EMAIL_DESC + ADDRESS_DESC_AMY;
         assertCommandFailure(command, Email.MESSAGE_EMAIL_CONSTRAINTS);
 
+        // Test fails when prefix is edited to "a:" from "a/".
         /* Case: invalid address -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + INVALID_ADDRESS_DESC;
         assertCommandFailure(command, Address.MESSAGE_ADDRESS_CONSTRAINTS);

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -91,7 +91,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         editedPerson = new PersonBuilder(personToEdit).withTags(VALID_TAG_FRIEND).build();
         assertCommandSuccess(command, index, editedPerson);
 
-        // Test fails when prefix is edited to "t:" from "t/".
+        // Test fails when prefix is edited to "t: " from "t:".
         /* Case: clear tags -> cleared */
         index = INDEX_FIRST_PERSON;
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + PREFIX_TAG.getPrefix();

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -91,6 +91,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         editedPerson = new PersonBuilder(personToEdit).withTags(VALID_TAG_FRIEND).build();
         assertCommandSuccess(command, index, editedPerson);
 
+        // Test fails when prefix is edited to "t:" from "t/".
         /* Case: clear tags -> cleared */
         index = INDEX_FIRST_PERSON;
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + PREFIX_TAG.getPrefix();


### PR DESCRIPTION
**Enchancement**: Change prefixes from the form "x/" to "x:", where x is any letter prefix.

**What works**: Prefixes for name, phone and email are able to be edited, passing all existing test cases.

**What does not work**: 
- Editing the prefixes for address and tags cause the AddCommandSystemTest and EditCommandSystemTest to fail.
- Test cases that are failing are the corner ones.

I am submitting a PR first so I can verify that editing the first three prefixes passes Travis and AppVeyor build checks. I will push the other commits up when I am done debugging.