### PR TITLE
Rework underlying implementation for keyboard shortcuts

### DIFF
--- a/src/main/java/seedu/address/commons/events/ui/ExecuteCommandRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/ExecuteCommandRequestEvent.java
@@ -1,44 +1,20 @@
 package seedu.address.commons.events.ui;
 
 import seedu.address.commons.events.BaseEvent;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.HistoryCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.RedoCommand;
-import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.ImmediatelyExecutableCommand;
 
 /**
  * Indicates that a new result is available.
  */
 public class ExecuteCommandRequestEvent extends BaseEvent {
+    public final String commandWord;
 
-    public final String commandPreamble;
-
-    public ExecuteCommandRequestEvent(String command) {
-        switch (command) {
-        case "clear":
-            commandPreamble = ClearCommand.COMMAND_WORD;
-            break;
-        case "history":
-            commandPreamble = HistoryCommand.COMMAND_WORD;
-            break;
-        case "list":
-            commandPreamble = ListCommand.COMMAND_WORD;
-            break;
-        case "redo":
-            commandPreamble = RedoCommand.COMMAND_WORD;
-            break;
-        case "undo":
-            commandPreamble = UndoCommand.COMMAND_WORD;
-            break;
-        default:
-            commandPreamble = UndoCommand.COMMAND_WORD;
-            // should be exception
-        }
+    public ExecuteCommandRequestEvent(ImmediatelyExecutableCommand command) {
+        commandWord = command.getCommandWord();
     }
 
     @Override
     public String toString() {
-        return this.getClass().getSimpleName() + ": " + commandPreamble;
+        return this.getClass().getSimpleName() + ": " + commandWord;
     }
 }

--- a/src/main/java/seedu/address/commons/events/ui/PopulatePrefixesRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/PopulatePrefixesRequestEvent.java
@@ -1,19 +1,7 @@
 package seedu.address.commons.events.ui;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
 import seedu.address.commons.events.BaseEvent;
-
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.LocateCommand;
-import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.PopulatableCommand;
 
 /**
  * Indicates that a new result is available.
@@ -23,61 +11,17 @@ public class PopulatePrefixesRequestEvent extends BaseEvent {
     public final String commandUsageMessage;
     public final String commandTemplate;
     public final int caretIndex;
-    private final String commandPreamble;
+    private final String commandWord;
 
-    public PopulatePrefixesRequestEvent(String command) {
-        switch (command) {
-        case "add":
-            commandPreamble = AddCommand.COMMAND_WORD;
-            commandUsageMessage = AddCommand.MESSAGE_USAGE;
-            commandTemplate = commandPreamble
-                    + " " + PREFIX_NAME
-                    + "  " + PREFIX_PHONE
-                    + "  " + PREFIX_EMAIL
-                    + "  " + PREFIX_ADDRESS
-                    + "  " + PREFIX_TAG + " ";
-            caretIndex = (AddCommand.COMMAND_WORD + " " + PREFIX_NAME + " ").length();
-            break;
-        case "delete":
-            commandPreamble = DeleteCommand.COMMAND_WORD;
-            commandUsageMessage = DeleteCommand.MESSAGE_USAGE;
-            commandTemplate = commandPreamble + " ";
-            caretIndex = commandTemplate.length();
-            break;
-        case "edit":
-            commandPreamble = EditCommand.COMMAND_WORD;
-            commandUsageMessage = EditCommand.MESSAGE_USAGE;
-            commandTemplate = commandPreamble
-                    + "  " + PREFIX_NAME
-                    + "  " + PREFIX_PHONE
-                    + "  " + PREFIX_EMAIL
-                    + "  " + PREFIX_ADDRESS
-                    + "  " + PREFIX_TAG;
-            caretIndex = (EditCommand.COMMAND_WORD + " ").length();
-            break;
-        case "find":
-            commandPreamble = FindCommand.COMMAND_WORD;
-            commandUsageMessage = FindCommand.MESSAGE_USAGE;
-            commandTemplate = commandPreamble + " -";
-            caretIndex = commandTemplate.length();
-            break;
-        case "locate":
-            commandPreamble = LocateCommand.COMMAND_WORD;
-            commandUsageMessage = LocateCommand.MESSAGE_USAGE;
-            commandTemplate = commandPreamble + " ";
-            caretIndex = commandTemplate.length();
-            break;
-        default:
-            commandPreamble = SelectCommand.COMMAND_WORD;
-            commandUsageMessage = SelectCommand.MESSAGE_USAGE;
-            commandTemplate = commandPreamble + " ";
-            caretIndex = commandTemplate.length();
-            // should be exception
-        }
+    public PopulatePrefixesRequestEvent(PopulatableCommand command) {
+        commandUsageMessage = command.getUsageMessage();
+        commandTemplate = command.getTemplate();
+        caretIndex = command.getCaretIndex();
+        commandWord = command.getCommandWord();
     }
 
     @Override
     public String toString() {
-        return this.getClass().getSimpleName() + ": " + commandPreamble;
+        return this.getClass().getSimpleName() + ": " + commandWord;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends UndoableCommand {
+public class AddCommand extends UndoableCommand implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "add";
     public static final String COMMAND_ALIAS = "a";
@@ -66,5 +66,27 @@ public class AddCommand extends UndoableCommand {
         return other == this // short circuit if same object
                 || (other instanceof AddCommand // instanceof handles nulls
                 && toAdd.equals(((AddCommand) other).toAdd));
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public String getTemplate() {
+        return COMMAND_WORD + " " + PREFIX_TYPE + "  " + PREFIX_NAME + "  "
+                + PREFIX_PHONE + "  " + PREFIX_EMAIL + "  " + PREFIX_ADDRESS + "  "
+                + PREFIX_TAG + " ";
+    }
+
+    @Override
+    public int getCaretIndex() {
+        return (COMMAND_WORD + " " + PREFIX_TYPE + " ").length();
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return MESSAGE_USAGE;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -22,19 +22,19 @@ public class AddCommand extends UndoableCommand implements PopulatableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_TYPE + "r(or c) "
-            + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + PREFIX_TYPE + " r(or c) "
+            + PREFIX_NAME + " NAME "
+            + "[" + PREFIX_PHONE + " PHONE] "
+            + "[" + PREFIX_EMAIL + " EMAIL] "
+            + "[" + PREFIX_ADDRESS + " ADDRESS] "
+            + "[" + PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_TYPE + "c "
-            + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TYPE + " c "
+            + PREFIX_NAME + " John Doe "
+            + PREFIX_PHONE + " 98765432 "
+            + PREFIX_EMAIL + " johnd@example.com "
+            + PREFIX_ADDRESS + " 311, Clementi Ave 2, #02-25 "
+            + PREFIX_TAG + " owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -49,6 +49,13 @@ public class AddCommand extends UndoableCommand implements PopulatableCommand {
         toAdd = person;
     }
 
+    /**
+     * For call in PopulatePrefixRequestEvent class, to assign string values.
+     */
+    public AddCommand() {
+        toAdd = null;
+    }
+
     @Override
     public CommandResult executeUndoableCommand() throws CommandException {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -7,17 +7,21 @@ import seedu.address.model.AddressBook;
 /**
  * Clears the address book.
  */
-public class ClearCommand extends UndoableCommand {
+public class ClearCommand extends UndoableCommand implements ImmediatelyExecutableCommand {
 
     public static final String COMMAND_WORD = "clear";
     public static final String COMMAND_ALIAS = "c";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-
 
     @Override
     public CommandResult executeUndoableCommand() {
         requireNonNull(model);
         model.resetData(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
 /**
  * Deletes a person identified using it's last displayed index from the address book.
  */
-public class DeleteCommand extends UndoableCommand {
+public class DeleteCommand extends UndoableCommand implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "delete";
     public static final String COMMAND_ALIAS = "d";
@@ -64,5 +64,25 @@ public class DeleteCommand extends UndoableCommand {
                 || (other instanceof DeleteCommand // instanceof handles nulls
                 && this.targetIndex.equals(((DeleteCommand) other).targetIndex) // state check
                 && Objects.equals(this.personToDelete, ((DeleteCommand) other).personToDelete));
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public String getTemplate() {
+        return COMMAND_WORD + " ";
+    }
+
+    @Override
+    public int getCaretIndex() {
+        return getTemplate().length();
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return MESSAGE_USAGE;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -34,6 +34,13 @@ public class DeleteCommand extends UndoableCommand implements PopulatableCommand
         this.targetIndex = targetIndex;
     }
 
+    /**
+     * For call in PopulatePrefixRequestEvent class, to assign string values.
+     */
+    public DeleteCommand() {
+        targetIndex = null;
+    }
+
 
     @Override
     public CommandResult executeUndoableCommand() {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -77,6 +77,15 @@ public class EditCommand extends UndoableCommand implements PopulatableCommand {
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
     }
 
+    /**
+     * For call in PopulatePrefixRequestEvent class, to assign string values.
+     */
+    public EditCommand() {
+        index = null;
+        editPersonDescriptor = null;
+    }
+
+
     @Override
     public CommandResult executeUndoableCommand() throws CommandException {
         try {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -37,7 +37,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditCommand extends UndoableCommand {
+public class EditCommand extends UndoableCommand implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "edit";
     public static final String COMMAND_ALIAS = "e";
@@ -165,6 +165,27 @@ public class EditCommand extends UndoableCommand {
         return index.equals(e.index)
                 && editPersonDescriptor.equals(e.editPersonDescriptor)
                 && Objects.equals(personToEdit, e.personToEdit);
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public String getTemplate() {
+        return COMMAND_WORD + "  " + PREFIX_NAME + "  " + PREFIX_PHONE + "  "
+                + PREFIX_EMAIL + "  " + PREFIX_ADDRESS + "  " + PREFIX_TAG + " ";
+    }
+
+    @Override
+    public int getCaretIndex() {
+        return (COMMAND_WORD + " ").length();
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return MESSAGE_USAGE;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -26,6 +26,14 @@ public class FindCommand extends Command implements PopulatableCommand {
         this.predicate = predicate;
     }
 
+    /**
+     * For call in PopulatePrefixRequestEvent class, to assign string values.
+     */
+    public FindCommand() {
+        predicate = null;
+    }
+
+
     @Override
     public CommandResult execute() {
         model.updateFilteredPersonList(predicate);

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.person.Person;
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case sensitive.
  */
-public class FindCommand extends Command {
+public class FindCommand extends Command implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "find";
     public static final String COMMAND_ALIAS = "f";
@@ -38,5 +38,25 @@ public class FindCommand extends Command {
                 || (other instanceof FindCommand // instanceof handles nulls
                 && this.predicate.equals(((FindCommand) other).predicate));
         // state check
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public String getTemplate() {
+        return COMMAND_WORD + " -";
+    }
+
+    @Override
+    public int getCaretIndex() {
+        return getTemplate().length();
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return MESSAGE_USAGE;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HistoryCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 /**
  * Lists all the commands entered by user from the start of app launch.
  */
-public class HistoryCommand extends Command {
+public class HistoryCommand extends Command implements ImmediatelyExecutableCommand {
 
     public static final String COMMAND_WORD = "history";
     public static final String COMMAND_ALIAS = "h";
@@ -35,5 +35,10 @@ public class HistoryCommand extends Command {
     public void setData(Model model, CommandHistory history, UndoRedoStack undoRedoStack) {
         requireNonNull(history);
         this.history = history;
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ImmediatelyExecutableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImmediatelyExecutableCommand.java
@@ -6,6 +6,6 @@ package seedu.address.logic.commands;
  * keyboard shortcuts.
  */
 public interface ImmediatelyExecutableCommand {
-    /** Returns the COMMAND_WORD of the Command */
+    /** Returns the command word of the Command */
     String getCommandWord();
 }

--- a/src/main/java/seedu/address/logic/commands/ImmediatelyExecutableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImmediatelyExecutableCommand.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.commands;
+
+/**
+ * This interface is utilised in the {@code ExecuteCommandRequestEvent} class, where it is used
+ * to provide a handle to {@code Commands} that immediately execute on press of their respective
+ * keyboard shortcuts.
+ */
+public interface ImmediatelyExecutableCommand {
+    /** Returns the COMMAND_WORD of the Command */
+    String getCommandWord();
+}

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -5,7 +5,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 /**
  * Lists all persons in the address book to the user.
  */
-public class ListCommand extends Command {
+public class ListCommand extends Command implements ImmediatelyExecutableCommand {
 
     public static final String COMMAND_WORD = "list";
     public static final String COMMAND_ALIAS = "l";
@@ -16,5 +16,10 @@ public class ListCommand extends Command {
     public CommandResult execute() {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/LocateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LocateCommand.java
@@ -13,7 +13,7 @@ import seedu.address.ui.MainWindow;
 /**
  * Display the place identified using its las displayed index from the address book
  */
-public class LocateCommand extends Command {
+public class LocateCommand extends Command implements PopulatableCommand {
     public static final String COMMAND_WORD = "locate";
     public static final String COMMAND_ALIAS = "lo";
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -56,5 +56,25 @@ public class LocateCommand extends Command {
         return other == this // short circuit if same object
                 || (other instanceof LocateCommand // instanceof handles nulls
                 && this.targetIndex.equals(((LocateCommand) other).targetIndex)); //start check
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public String getTemplate() {
+        return COMMAND_WORD + " ";
+    }
+
+    @Override
+    public int getCaretIndex() {
+        return getTemplate().length();
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return MESSAGE_USAGE;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/LocateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LocateCommand.java
@@ -27,8 +27,15 @@ public class LocateCommand extends Command implements PopulatableCommand {
 
     public LocateCommand (Index targetIndex) {
         this.targetIndex = targetIndex;
-
     }
+
+    /**
+     * For call in PopulatePrefixRequestEvent class, to assign string values.
+     */
+    public LocateCommand() {
+        targetIndex = null;
+    }
+
 
     @Override
     public CommandResult execute() throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/PopulatableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PopulatableCommand.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+/**
+ * This interface is utilised in the {@code ExecuteCommandRequestEvent} class, where it is used
+ * to provide a handle to {@code Commands} that immediately execute on press of their respective
+ * keyboard shortcuts.
+ */
+public interface PopulatableCommand {
+    /** Returns the command word of the Command */
+    String getCommandWord();
+
+    /** Returns the complete template (command word + all prefixes) of the Command */
+    String getTemplate();
+
+    /** Returns the index where the cursor should be after population of the Command */
+    int getCaretIndex();
+
+    /** Returns the usage message of the Command */
+    String getUsageMessage();
+}

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
 /**
  * Redo the previously undone command.
  */
-public class RedoCommand extends Command {
+public class RedoCommand extends Command implements ImmediatelyExecutableCommand {
 
     public static final String COMMAND_WORD = "redo";
     public static final String COMMAND_ALIAS = "r";
@@ -33,5 +33,10 @@ public class RedoCommand extends Command {
     public void setData(Model model, CommandHistory commandHistory, UndoRedoStack undoRedoStack) {
         this.model = model;
         this.undoRedoStack = undoRedoStack;
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -29,6 +29,14 @@ public class SelectCommand extends Command implements PopulatableCommand {
         this.targetIndex = targetIndex;
     }
 
+    /**
+     * For call in PopulatePrefixRequestEvent class, to assign string values.
+     */
+    public SelectCommand() {
+        targetIndex = null;
+    }
+
+
     @Override
     public CommandResult execute() throws CommandException {
 

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.Person;
 /**
  * Selects a person identified using it's last displayed index from the address book.
  */
-public class SelectCommand extends Command {
+public class SelectCommand extends Command implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "select";
     public static final String COMMAND_ALIAS = "s";
@@ -48,5 +48,25 @@ public class SelectCommand extends Command {
         return other == this // short circuit if same object
                 || (other instanceof SelectCommand // instanceof handles nulls
                 && this.targetIndex.equals(((SelectCommand) other).targetIndex)); // state check
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public String getTemplate() {
+        return COMMAND_WORD + " ";
+    }
+
+    @Override
+    public int getCaretIndex() {
+        return getTemplate().length();
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return MESSAGE_USAGE;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
 /**
  * Undo the previous {@code UndoableCommand}.
  */
-public class UndoCommand extends Command {
+public class UndoCommand extends Command implements ImmediatelyExecutableCommand {
 
     public static final String COMMAND_WORD = "undo";
     public static final String COMMAND_ALIAS = "u";
@@ -33,5 +33,10 @@ public class UndoCommand extends Command {
     public void setData(Model model, CommandHistory commandHistory, UndoRedoStack undoRedoStack) {
         this.model = model;
         this.undoRedoStack = undoRedoStack;
+    }
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
     }
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -147,7 +147,7 @@ public class CommandBox extends UiPart<Region> {
      */
     @Subscribe
     private void handleExecuteCommandRequestEvent(ExecuteCommandRequestEvent event) {
-        replaceText(event.commandPreamble);
+        replaceText(event.commandWord);
         handleCommandInputChanged();
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -20,6 +20,7 @@ import seedu.address.commons.events.ui.ExitAppRequestEvent;
 import seedu.address.commons.events.ui.PopulatePrefixesRequestEvent;
 import seedu.address.commons.events.ui.ShowHelpRequestEvent;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.*;
 import seedu.address.model.UserPrefs;
 
 /**
@@ -229,7 +230,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleUndo() {
-        raise(new ExecuteCommandRequestEvent("undo"));
+        raise(new ExecuteCommandRequestEvent(new UndoCommand()));
     }
 
     /**
@@ -237,7 +238,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleRedo() {
-        raise(new ExecuteCommandRequestEvent("redo"));
+        raise(new ExecuteCommandRequestEvent(new RedoCommand()));
     }
 
     /**
@@ -245,7 +246,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleClear() {
-        raise(new ExecuteCommandRequestEvent("clear"));
+        raise(new ExecuteCommandRequestEvent(new ClearCommand()));
     }
 
     /**
@@ -253,7 +254,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleHistory() {
-        raise(new ExecuteCommandRequestEvent("history"));
+        raise(new ExecuteCommandRequestEvent(new HistoryCommand()));
     }
 
     /**
@@ -261,7 +262,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleList() {
-        raise(new ExecuteCommandRequestEvent("list"));
+        raise(new ExecuteCommandRequestEvent(new ListCommand()));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -20,7 +20,17 @@ import seedu.address.commons.events.ui.ExitAppRequestEvent;
 import seedu.address.commons.events.ui.PopulatePrefixesRequestEvent;
 import seedu.address.commons.events.ui.ShowHelpRequestEvent;
 import seedu.address.logic.Logic;
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.LocateCommand;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.UserPrefs;
 
 /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -270,7 +270,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleFind() {
-        raise(new PopulatePrefixesRequestEvent("find"));
+        raise(new PopulatePrefixesRequestEvent(new FindCommand()));
     }
 
     /**
@@ -278,7 +278,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleAdd() {
-        raise(new PopulatePrefixesRequestEvent("add"));
+        raise(new PopulatePrefixesRequestEvent(new AddCommand()));
     }
 
     /**
@@ -286,7 +286,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleDelete() {
-        raise(new PopulatePrefixesRequestEvent("delete"));
+        raise(new PopulatePrefixesRequestEvent(new DeleteCommand()));
     }
 
     /**
@@ -294,7 +294,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleEdit() {
-        raise(new PopulatePrefixesRequestEvent("edit"));
+        raise(new PopulatePrefixesRequestEvent(new EditCommand()));
     }
 
     /**
@@ -302,7 +302,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleLocate() {
-        raise(new PopulatePrefixesRequestEvent("locate"));
+        raise(new PopulatePrefixesRequestEvent(new LocateCommand()));
     }
 
     /**
@@ -310,7 +310,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleSelect() {
-        raise(new PopulatePrefixesRequestEvent("select"));
+        raise(new PopulatePrefixesRequestEvent(new SelectCommand()));
     }
 
     void show() {


### PR DESCRIPTION
**Previous problem**: `switch` statements were used in both the `ExecuteCommandRequestEvent` and the `PopulatePrefixesRequestEvent` classes to initialise values. Inelegant implementation.

**New implementation**: two new interfaces are introduced: `ImmediatelyExecutableCommand` and `PopulatableCommand`. Each command that has a keyboard shortcut defined for it will implement exactly one of these two interfaces. This way, both of the above-mentioned event classes now have convenient handles to whatever commands that are passed into their constructors and we can make use of polymorphism to use the same code to extract the respective string values.

**Limitations**: this implementation is still inelegant in that the constructors for all the commands that implement the `PopulatableCommand` have to be overloaded with constructors with no arguments.
Not good but better than before.

Other possible solutions: Editing the abstract Command superclass. Will explore.