### PR TITLE
Change alias of LocateCommand and ListCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -8,7 +8,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 public class ListCommand extends Command implements ImmediatelyExecutableCommand {
 
     public static final String COMMAND_WORD = "list";
-    public static final String COMMAND_ALIAS = "l";
+    public static final String COMMAND_ALIAS = "li";
     public static final String MESSAGE_SUCCESS = "Listed all persons.";
 
 

--- a/src/main/java/seedu/address/logic/commands/LocateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LocateCommand.java
@@ -15,7 +15,7 @@ import seedu.address.ui.MainWindow;
  */
 public class LocateCommand extends Command implements PopulatableCommand {
     public static final String COMMAND_WORD = "locate";
-    public static final String COMMAND_ALIAS = "lo";
+    public static final String COMMAND_ALIAS = "l";
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + " | Locates all persons whose fields contain any of the specified keywords "
             + "(case-insensitive) and displays them as a list with index numbers."


### PR DESCRIPTION
Considering about the function of both the command, it's more friendly to use "l" for LocateCommand and "li" for ListCommand.

- change alias of LocateCommand from "lo" to "l"

- change alias of ListCommand from "l" to "li"