### PR TITLE
Tab moves caret to the next prefix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -23,6 +23,9 @@ public class AddCommand extends UndoableCommand implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "add";
     public static final String COMMAND_ALIAS = "i";
+    public static final String COMMAND_TEMPLATE = COMMAND_WORD + " " + PREFIX_TYPE + "  " + PREFIX_NAME + "  "
+            + PREFIX_PHONE + "  " + PREFIX_EMAIL + "  " + PREFIX_ADDRESS + "  " + PREFIX_OWESTARTDATE + "  "
+            + PREFIX_OWEDUEDATE + "  " + PREFIX_MONEY_BORROWED + "  " + PREFIX_INTEREST + "  " + PREFIX_TAG + " ";
 
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + " | Adds a Customer or Runner with the specified details. "
@@ -111,10 +114,7 @@ public class AddCommand extends UndoableCommand implements PopulatableCommand {
 
     @Override
     public String getTemplate() {
-        return COMMAND_WORD + " " + PREFIX_TYPE + "  " + PREFIX_NAME + "  "
-                + PREFIX_PHONE + "  " + PREFIX_EMAIL + "  " + PREFIX_ADDRESS + "  "
-                + PREFIX_OWESTARTDATE + "  " + PREFIX_OWEDUEDATE + "  "
-                + PREFIX_MONEY_BORROWED + "  " + PREFIX_INTEREST + "  " + PREFIX_TAG + " ";
+        return COMMAND_TEMPLATE;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -23,6 +23,7 @@ public class DeleteCommand extends UndoableCommand implements PopulatableCommand
 
     public static final String COMMAND_WORD = "delete";
     public static final String COMMAND_ALIAS = "d";
+    public static final String COMMAND_TEMPLATE = COMMAND_WORD + " ";
 
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + " | Deletes the person associated with the index number used in the last person listing. "
@@ -174,7 +175,7 @@ public class DeleteCommand extends UndoableCommand implements PopulatableCommand
 
     @Override
     public String getTemplate() {
-        return COMMAND_WORD + " ";
+        return COMMAND_TEMPLATE;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -48,6 +48,9 @@ public class EditCommand extends UndoableCommand implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "edit";
     public static final String COMMAND_ALIAS = "e";
+    public static final String COMMAND_TEMPLATE = COMMAND_WORD + "  " + PREFIX_NAME + "  " + PREFIX_PHONE + "  "
+            + PREFIX_EMAIL + "  " + PREFIX_ADDRESS + "  " + PREFIX_OWESTARTDATE + "  " + PREFIX_OWEDUEDATE + "  "
+            + PREFIX_MONEY_BORROWED + "  " + PREFIX_INTEREST + "  " + PREFIX_TAG + " ";
 
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + " | Edits the details of the person identified "
@@ -221,7 +224,7 @@ public class EditCommand extends UndoableCommand implements PopulatableCommand {
 
     @Override
     public String getTemplate() {
-        return COMMAND_WORD + " ";
+        return COMMAND_TEMPLATE;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -54,27 +54,27 @@ public class EditCommand extends UndoableCommand implements PopulatableCommand {
 
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + " | Edits the details of the person identified "
-                    + "by the index number used in the last person listing."
-                    + "\n\tEditable fields are NAME, PHONE, EMAIL, ADDRESS, MONEY_BORROWED, WEEKLY_INTEREST, "
-                    + "OWE_START_DATE, "
-                    + "OWE_DUE_DATE."
-                    + "\n\t"
-                    + "Existing values will be overwritten by the input values. "
+                    + "by the index number used in the last person listing. "
                     + "Refer to the User Guide (press \"F1\") for detailed information about this command!"
 
                     + "\n\t"
                     + "Parameters:\t"
                     + COMMAND_WORD + " "
-                    + "INDEX (must be a positive integer) "
+                    + "INDEX "
                     + "[" + PREFIX_NAME + " NAME] "
                     + "[" + PREFIX_PHONE + " PHONE] "
                     + "[" + PREFIX_EMAIL + " EMAIL] "
                     + "[" + PREFIX_ADDRESS + " ADDRESS] "
-                    + "[" + PREFIX_TAG + " TAG]"
-                    + "\n\t[" + PREFIX_MONEY_BORROWED + " MONEY_BORROWED] "
+                    + "[" + PREFIX_MONEY_BORROWED + " MONEY_BORROWED] "
                     + "[" + PREFIX_INTEREST + " WEEKLY_INTEREST] "
                     + "[" + PREFIX_OWESTARTDATE + " OWE_START_DATE] "
                     + "[" + PREFIX_OWEDUEDATE + " OWE_DUE_DATE] "
+                    + "[" + PREFIX_TAG + " TAG] ..."
+
+                    + "\n\t\t"
+                    + "1. Existing values will be overwritten by the input values."
+                    + "\n"
+                    + "2. At least one of the optional fields must be provided."
 
                     + "\n\t"
                     + "Example:\t\t"
@@ -229,7 +229,7 @@ public class EditCommand extends UndoableCommand implements PopulatableCommand {
 
     @Override
     public int getCaretIndex() {
-        return getTemplate().length();
+        return (COMMAND_WORD + " ").length();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -14,6 +14,7 @@ public class FindCommand extends Command implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "find";
     public static final String COMMAND_ALIAS = "f";
+    public static final String COMMAND_TEMPLATE = COMMAND_WORD + " -";
 
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + " | Finds all persons whose fields contain any of the specified keywords (case-insensitive) "
@@ -66,7 +67,7 @@ public class FindCommand extends Command implements PopulatableCommand {
 
     @Override
     public String getTemplate() {
-        return COMMAND_WORD + " -";
+        return COMMAND_TEMPLATE;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -16,6 +16,7 @@ public class SelectCommand extends Command implements PopulatableCommand {
 
     public static final String COMMAND_WORD = "select";
     public static final String COMMAND_ALIAS = "s";
+    public static final String COMMAND_TEMPLATE = COMMAND_WORD + " ";
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + " | Selects the person identified by the index number used in the last person listing. "
             + "Refer to the User Guide (press \"F1\") for detailed information about this command!"
@@ -73,7 +74,7 @@ public class SelectCommand extends Command implements PopulatableCommand {
 
     @Override
     public String getTemplate() {
-        return COMMAND_WORD + " ";
+        return COMMAND_TEMPLATE;
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -141,6 +141,15 @@ public class CommandBox extends UiPart<Region> {
         commandTextField.positionCaret(newCaretPosition);
     }
 
+    /**
+     * Positions the caret after the next {@code prefix}.
+     */
+    private void moveToNextPrefix() {
+        int currentCaretPosition = commandTextField.getCaretPosition();
+        int newCaretPosition = getNextPrefixPosition(currentCaretPosition);
+        commandTextField.positionCaret(newCaretPosition);
+    }
+
     private int getPreviousPrefixPosition(int currentCaretPosition) {
         // find last prefix position
         int previousPrefixPosition = commandTextField.getText().lastIndexOf(":", currentCaretPosition);

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -132,6 +132,15 @@ public class CommandBox extends UiPart<Region> {
     }
 
     //@@author jonleeyz
+    /**
+     * Positions the caret after the last {@code prefix}.
+     */
+    private void moveToPreviousPrefix() {
+        int currentCaretPosition = commandTextField.getCaretPosition();
+        int newCaretPosition = getPreviousPrefixPosition(currentCaretPosition);
+        commandTextField.positionCaret(newCaretPosition);
+    }
+
     private int getPreviousPrefixPosition(int currentCaretPosition) {
         // find last prefix position
         int previousPrefixPosition = commandTextField.getText().lastIndexOf(":", currentCaretPosition);

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -133,6 +133,21 @@ public class CommandBox extends UiPart<Region> {
 
     //@@author jonleeyz
     /**
+     * Removes the current {@code field} or {@code prefix}.
+     */
+    private void clearCurrentFieldOrPrefix() {
+        int currentCaretPosition = commandTextField.getCaretPosition();
+        int lastPrefixPosition = getPreviousPrefixPosition(currentCaretPosition);
+
+        // clearing the current field or prefix
+        String stringLiteralUpToPrefix = commandTextField.getText().substring(0, lastPrefixPosition);
+        String stringLiteralAfterCaret = commandTextField.getText().substring(currentCaretPosition);
+        String newCommandBoxText = stringLiteralUpToPrefix + stringLiteralAfterCaret;
+        commandTextField.setText(newCommandBoxText);
+        commandTextField.positionCaret(lastPrefixPosition);
+    }
+
+    /**
      * Positions the caret after the last {@code prefix}.
      */
     private void moveToPreviousPrefix() {

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -132,6 +132,46 @@ public class CommandBox extends UiPart<Region> {
     }
 
     //@@author jonleeyz
+    private int getPreviousPrefixPosition(int currentCaretPosition) {
+        // find last prefix position
+        int previousPrefixPosition = commandTextField.getText().lastIndexOf(":", currentCaretPosition);
+
+        // if last prefix is too close to caret, find the second last prefix position
+        if (currentCaretPosition - previousPrefixPosition < 3) {
+            previousPrefixPosition = commandTextField.getText().lastIndexOf(":",previousPrefixPosition - 1);
+        }
+
+        // set new caret position to be in front of chosen prefix. If prefix not found, then set at index 0.
+        int newCaretPosition = previousPrefixPosition != -1 ? previousPrefixPosition + 1 : 0;
+
+        // check for space in front of last prefix. If present, move forward one more index.
+        if (commandTextField.getText().substring(newCaretPosition, newCaretPosition + 1).equals(" ")) {
+            newCaretPosition += 1;
+        }
+
+        return newCaretPosition;
+    }
+
+    private int getNextPrefixPosition(int currentCaretPosition) {
+        // find next prefix position
+        int nextPrefixPosition = commandTextField.getText().indexOf(":", currentCaretPosition);
+        int newCaretPosition;
+
+        // set new caret position to be in front of chosen prefix. If prefix not found, then set at last index.
+        if (nextPrefixPosition != -1) {
+            newCaretPosition = nextPrefixPosition + 1;
+
+            // check for space in front of last prefix. If present, move forward one more index.
+            if (commandTextField.getText().substring(newCaretPosition, newCaretPosition + 1).equals(" ")) {
+                newCaretPosition += 1;
+            }
+        } else {
+            newCaretPosition = commandTextField.getText().length();
+        }
+
+        return newCaretPosition;
+    }
+
     /**
      * Handles the event where a valid keyboard shortcut is pressed
      * to populate the CommandBox with command prefixes,

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -60,6 +60,19 @@ public class CommandBox extends UiPart<Region> {
             keyEvent.consume();
             navigateToNextInput();
             break;
+        case TAB:
+            keyEvent.consume();
+            if (keyEvent.isShiftDown()) {
+                moveToPreviousPrefix();
+            } else {
+                moveToNextPrefix();
+            }
+            break;
+        case BACK_SPACE:
+            if (keyEvent.isShiftDown()) {
+                keyEvent.consume();
+                clearCurrentFieldOrPrefix();
+            }
         default:
             // let JavaFx handle the keypress
         }

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -39,13 +39,37 @@ public class CommandBoxHandle extends NodeHandle<TextField> {
 
     //@@author jonleeyz
     /**
-     * Clears all text in the Command Box.
+     * Sets text in the command box
+     */
+    public boolean setInput(String text) {
+        click();
+        guiRobot.interact(() -> getRootNode().setText(text));
+        return !getStyleClass().contains(CommandBox.ERROR_STYLE_CLASS);
+    }
+
+    /**
+     * Clears all text in the command box.
      * @return true if the command succeeded, false otherwise.
      */
     public boolean clear() {
         click();
         guiRobot.interact(() -> getRootNode().clear());
         return getRootNode().getText().equals("");
+    }
+
+    /**
+     * Gets caret position in the command box
+     */
+    public int getCaretPosition() {
+        return getRootNode().getCaretPosition();
+    }
+
+    /**
+     * Sets caret position in the command box
+     */
+    public void setCaretPosition(int index) {
+        click();
+        guiRobot.interact(() -> getRootNode().positionCaret(index));
     }
     //@@author
 

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -15,6 +15,7 @@ import javafx.scene.input.KeyCode;
 import seedu.address.commons.events.ui.NewResultAvailableEvent;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -132,6 +133,142 @@ public class CommandBoxTest extends GuiUnitTest {
         assertInputHistory(KeyCode.DOWN, "");
         assertInputHistory(KeyCode.UP, thirdCommand);
     }
+
+    //@@author jonleeyz
+    @Test
+    public void handleKeyPress_tab() {
+        commandBoxHandle.setInput(AddCommand.COMMAND_TEMPLATE);
+        String testString = "";
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        // @TODO to be extended
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat("add ty: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" n: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" p: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" e: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" s: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" d: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" m: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" i: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.TAB);
+        testString = testString.concat(" t: ");
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+    }
+
+    @Test
+    public void handleKeyPress_shiftTab() {
+        commandBoxHandle.setInput(AddCommand.COMMAND_TEMPLATE);
+        commandBoxHandle.setCaretPosition(commandBoxHandle.getInput().length());
+        String testString = AddCommand.COMMAND_TEMPLATE;
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        // @TODO to be extended
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.TAB);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getCaretPosition(), testString.length());
+    }
+
+    @Test
+    public void handleKeyPress_shiftBackspace() {
+        commandBoxHandle.setInput(AddCommand.COMMAND_TEMPLATE);
+        commandBoxHandle.setCaretPosition(commandBoxHandle.getInput().length());
+        String testString = AddCommand.COMMAND_TEMPLATE;
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        // @TODO to be extended
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+
+        guiRobot.push(KeyCode.SHIFT, KeyCode.BACK_SPACE);
+        testString = testString.substring(0, testString.length() - 4);
+        assertEquals(commandBoxHandle.getInput().length(), testString.length());
+    }
+    //@@author
 
     //@@author jonleeyz-reused
     /**

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -298,9 +298,8 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
      * template was successful.
      */
     private void assertPopulationSuccess() {
-        AddCommand addCommand = new AddCommand();
-        assertEquals(addCommand.getTemplate(), getCommandBox().getInput());
-        assertEquals(addCommand.getUsageMessage(), getResultDisplay().getText());
+        assertEquals(AddCommand.COMMAND_TEMPLATE, getCommandBox().getInput());
+        assertEquals(AddCommand.MESSAGE_USAGE, getResultDisplay().getText());
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof PopulatePrefixesRequestEvent);
         // assertTrue(eventsCollectorRule.eventsCollector.getSize() == 1);
         guiRobot.pauseForHuman();

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -242,9 +242,8 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
      * template was successful.
      */
     private void assertPopulationSuccess() {
-        DeleteCommand deleteCommand = new DeleteCommand();
-        assertEquals(deleteCommand.getTemplate(), getCommandBox().getInput());
-        assertEquals(deleteCommand.getUsageMessage(), getResultDisplay().getText());
+        assertEquals(DeleteCommand.COMMAND_TEMPLATE, getCommandBox().getInput());
+        assertEquals(DeleteCommand.MESSAGE_USAGE, getResultDisplay().getText());
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof PopulatePrefixesRequestEvent);
         guiRobot.pauseForHuman();
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -331,9 +331,8 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
      * template was successful.
      */
     private void assertPopulationSuccess() {
-        EditCommand editCommand = new EditCommand();
-        assertEquals(editCommand.getTemplate(), getCommandBox().getInput());
-        assertEquals(editCommand.getUsageMessage(), getResultDisplay().getText());
+        assertEquals(EditCommand.COMMAND_TEMPLATE, getCommandBox().getInput());
+        assertEquals(EditCommand.MESSAGE_USAGE, getResultDisplay().getText());
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof PopulatePrefixesRequestEvent);
         guiRobot.pauseForHuman();
 

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -258,9 +258,8 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
      * template was successful.
      */
     private void assertPopulationSuccess() {
-        FindCommand findCommand = new FindCommand();
-        assertEquals(findCommand.getTemplate(), getCommandBox().getInput());
-        assertEquals(findCommand.getUsageMessage(), getResultDisplay().getText());
+        assertEquals(FindCommand.COMMAND_TEMPLATE, getCommandBox().getInput());
+        assertEquals(FindCommand.MESSAGE_USAGE, getResultDisplay().getText());
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof PopulatePrefixesRequestEvent);
         guiRobot.pauseForHuman();
 

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -199,9 +199,8 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
      * template was successful.
      */
     private void assertPopulationSuccess() {
-        SelectCommand selectCommand = new SelectCommand();
-        assertEquals(selectCommand.getTemplate(), getCommandBox().getInput());
-        assertEquals(selectCommand.getUsageMessage(), getResultDisplay().getText());
+        assertEquals(SelectCommand.COMMAND_TEMPLATE, getCommandBox().getInput());
+        assertEquals(SelectCommand.MESSAGE_USAGE, getResultDisplay().getText());
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof PopulatePrefixesRequestEvent);
         guiRobot.pauseForHuman();
 


### PR DESCRIPTION
- `Tab`: moves caret to after the next prefix
- `Shift` + `Tab`: moves caret to after the previous prefix
- `Shift` + `Backspace`: clears the current field or prefix

Tests not complete, will be done in a subsequent PR.